### PR TITLE
Add more range-related testing to fuzzing

### DIFF
--- a/fuzz/fuzz_targets/arbitrary_ops/mod.rs
+++ b/fuzz/fuzz_targets/arbitrary_ops/mod.rs
@@ -51,8 +51,20 @@ pub enum MutableBitmapOperation {
     RemoveRange(RangeInclusive<Num>),
     Clear,
     Extend(Vec<Num>),
+    SwapSerialization,
+    Optimize,
+    // TODO: not implemented in roaring-rs yet
+    // RemoveRunCompression,
     // Probably turn it into a bitmap
     MakeBitmap { key: u16 },
+    // Probably turn it into a Range
+    MakeRange { key: u16 },
+}
+
+#[derive(Arbitrary, Debug, Copy, Clone)]
+pub enum RangeOperations {
+    Optimized,
+    Removed,
 }
 
 #[derive(Arbitrary, Debug)]
@@ -67,11 +79,11 @@ pub enum ReadBitmapOperation {
     Maximum,
     Rank(Num),
     Select(Num),
-    Statistics,
+    Statistics(RangeOperations),
     Clone,
     Debug,
-    SerializedSize,
-    Serialize,
+    SerializedSize(RangeOperations),
+    Serialize(RangeOperations),
 }
 
 #[derive(Arbitrary, Debug)]
@@ -85,7 +97,7 @@ pub enum BitmapBinaryOperation {
 }
 
 impl ReadBitmapOperation {
-    pub fn apply(&self, x: &mut croaring::Bitmap, y: &roaring::RoaringBitmap) {
+    pub fn apply(&self, x: &mut croaring::Bitmap, y: &mut roaring::RoaringBitmap) {
         match *self {
             ReadBitmapOperation::ContainsRange(ref range) => {
                 let range = range.start().0..=range.end().0;
@@ -139,9 +151,18 @@ impl ReadBitmapOperation {
                 let actual = y.select(n);
                 assert_eq!(expected, actual);
             }
-            ReadBitmapOperation::Statistics => {
-                // roaring-rs doesn't support range containers (yet)
-                x.remove_run_compression();
+            ReadBitmapOperation::Statistics(ranges) => {
+                match ranges {
+                    RangeOperations::Optimized => {
+                        x.run_optimize();
+                        y.optimize();
+
+                    }
+                    RangeOperations::Removed => {
+                        // TODO: Not implemented in roaring-rs yet
+                        return;
+                    }
+                }
                 let expected = x.statistics();
                 let actual = y.statistics();
                 // Convert to the same statistics struct
@@ -174,16 +195,34 @@ impl ReadBitmapOperation {
                 use std::io::Write;
                 write!(std::io::sink(), "{:?}", y).unwrap();
             }
-            ReadBitmapOperation::SerializedSize => {
-                // roaring-rs doesn't support range containers (yet)
-                x.remove_run_compression();
+            ReadBitmapOperation::SerializedSize(ranges) => {
+                match ranges {
+                    RangeOperations::Optimized => {
+                        x.run_optimize();
+                        y.optimize();
+
+                    }
+                    RangeOperations::Removed => {
+                        // TODO: Not implemented in roaring-rs yet
+                        return;
+                    }
+                }
                 let expected = x.get_serialized_size_in_bytes::<croaring::Portable>();
                 let actual = y.serialized_size();
                 assert_eq!(expected, actual);
             }
-            ReadBitmapOperation::Serialize => {
-                // roaring-rs doesn't support range containers (yet)
-                x.remove_run_compression();
+            ReadBitmapOperation::Serialize(ranges) => {
+                match ranges {
+                    RangeOperations::Optimized => {
+                        x.run_optimize();
+                        y.optimize();
+
+                    }
+                    RangeOperations::Removed => {
+                        // TODO: Not implemented in roaring-rs yet
+                        return;
+                    }
+                }
                 let expected = x.serialize::<croaring::Portable>();
                 let mut actual = Vec::new();
                 y.serialize_into(&mut actual).unwrap();
@@ -230,11 +269,28 @@ impl MutableBitmapOperation {
                 x.clear();
                 y.clear();
             }
+            MutableBitmapOperation::Optimize => {
+                let expected_changed = x.run_optimize();
+                let actual_changed = y.optimize();
+                assert_eq!(expected_changed, actual_changed);
+            }
             MutableBitmapOperation::Extend(ref items) => {
                 // Safety - Num is repr(transparent) over u32
                 let items: &[u32] = unsafe { mem::transmute(&items[..]) };
                 x.add_many(items);
                 y.extend(items);
+            }
+            MutableBitmapOperation::SwapSerialization => {
+                let x_serialized = x.serialize::<croaring::Portable>();
+                let mut y_serialized = Vec::new();
+                y.serialize_into(&mut y_serialized).unwrap();
+
+                let new_x = croaring::Bitmap::try_deserialize::<croaring::Portable>(&y_serialized).unwrap();
+                let new_y = roaring::RoaringBitmap::deserialize_from(&x_serialized[..]).unwrap();
+                assert_eq!(new_x, *x);
+                assert_eq!(new_y, *y);
+                *x = new_x;
+                *y = new_y;
             }
             MutableBitmapOperation::MakeBitmap { key } => {
                 let key = u32::from(key);
@@ -244,6 +300,13 @@ impl MutableBitmapOperation {
                     x.add(i);
                     y.insert(i);
                 }
+            }
+            MutableBitmapOperation::MakeRange { key } => {
+                let key = u32::from(key);
+                let start = key * 0x1_0000;
+                let end = start + 9 * 1024;
+                x.add_range(start..=end);
+                y.insert_range(start..=end);
             }
         }
     }


### PR DESCRIPTION
This seems to catch something real, e.g.

```rust
FuzzInput {
    ops: [
        MutateLhs(
            InsertRange(
                Num(
                    24048,
                )..=Num(
                    228848,
                ),
            ),
        ),
        MutateLhs(
            SwapSerialization,
        ),
        Binary(
            Eq,
        ),
    ],
    initial_input: [],
}
```

Fails with

```
thread '<unnamed>' panicked at fuzz_targets/arbitrary_ops/mod.rs:381:17:
assertion `left == right` failed
  left: 131072
 right: 131071
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/d5b4c2e4f19b6d7037371cdaecc3cc2c701c68df/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/d5b4c2e4f19b6d7037371cdaecc3cc2c701c68df/library/core/src/panicking.rs:75:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /Users/zach/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panicking.rs:380:5
   4: against_croaring::arbitrary_ops::check_equal
             at ./fuzz/fuzz_targets/arbitrary_ops/mod.rs:381:17
   5: against_croaring::_::__libfuzzer_sys_run
             at ./fuzz/fuzz_targets/against_croaring.rs:36:5
```

(iterating a deserialized bitmap with range containers doesn't yield the same values.)